### PR TITLE
fix: prevent negative indent values in formatHTML helper

### DIFF
--- a/src/runtime/hydration/composables.ts
+++ b/src/runtime/hydration/composables.ts
@@ -17,14 +17,14 @@ function formatHTML(html: string | undefined): string {
       formatted += '\n' + '  '.repeat(Math.max(0, indent)) + tag
     }
     else if (tag.startsWith('<') && !tag.endsWith('/>') && !tag.includes('<!')) {
-      formatted += '\n' + '  '.repeat(indent) + tag
+      formatted += '\n' + '  '.repeat(Math.max(0, indent)) + tag
       indent++
     }
     else if (tag.startsWith('<')) {
-      formatted += '\n' + '  '.repeat(indent) + tag
+      formatted += '\n' + '  '.repeat(Math.max(0, indent)) + tag
     }
     else {
-      formatted += '\n' + '  '.repeat(indent) + tag.trim()
+      formatted += '\n' + '  '.repeat(Math.max(0, indent)) + tag.trim()
     }
   }
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

small improvement to the `formatHTML` function in `src/runtime/hydration/composables.ts`, ensuring that indentation is never negative when formatting HTML. The change uses `Math.max(0, indent)` instead of `indent` for all indentation calculations, which prevents potential formatting errors if `indent` becomes negative.
