### PR TITLE
fix: Add module to nuxt's transpile array

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -7,9 +7,11 @@ export interface ModuleOptions {
   devtools: boolean
 }
 
+const moduleName = '@nuxt/hints'
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
-    name: '@nuxt/hints',
+    name: moduleName,
     configKey: 'hints',
   },
   defaults: {
@@ -48,5 +50,7 @@ export default defineNuxtModule<ModuleOptions>({
       setupDevToolsUI(nuxt, resolver)
       addPlugin(resolver.resolve('./runtime/core/plugins/vue-tracer-state.client'))
     }
+
+    nuxt.options.build.transpile.push(moduleName)
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

#151

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using Nuxt with disable imports, module is throws error that 'Could not resolve "#imports"' this PR add module to transpile array on build. 

Let me know if there is anything to adjust. 
