### PR TITLE
fix(hydration): handle correctly vue compiler defineComponent import

### DIFF
--- a/test/unit/hydration/vite-plugin.test.ts
+++ b/test/unit/hydration/vite-plugin.test.ts
@@ -103,6 +103,26 @@ describe('InjectHydrationPlugin', () => {
       const result = await modifyImportPluginTransform(code, 'test.ts')
       expect(result).toBe(undefined)
     })
+
+    it('should handle aliased defineComponent import', async () => {
+      const code = `import { defineComponent as _defineComponent } from 'vue'\nexport default _defineComponent({})`
+      const result = await modifyImportPluginTransform(code, 'test.ts')
+      expect(result.code).toContain(genImport(
+        '@nuxt/hints/runtime/hydration/component',
+        [{ name: 'defineComponent', as: '_defineComponent' }],
+      ))
+      expect(result.code).not.toContain(`import { defineComponent as _defineComponent } from 'vue'`)
+    })
+
+    it('should handle aliased defineNuxtComponent import', async () => {
+      const code = `import { defineNuxtComponent as _defineNuxtComponent } from '#app'\nexport default _defineNuxtComponent({})`
+      const result = await modifyImportPluginTransform(code, 'test.ts')
+      expect(result.code).toContain(genImport(
+        '@nuxt/hints/runtime/hydration/component',
+        [{ name: 'defineNuxtComponent', as: '_defineNuxtComponent' }],
+      ))
+      expect(result.code).not.toContain(`import { defineNuxtComponent as _defineNuxtComponent } from '#app'`)
+    })
   })
 
   describe('inject-hydration-composable', () => {


### PR DESCRIPTION
### 🔗 Linked issue

this pr fixes the hydration plugin not correctly replacing `_defineComponent` injected by the vue compiler

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
