### PR TITLE
fix: search through all matching import declaration for findImportSpecifier

### DIFF
--- a/test/unit/hydration/vite-plugin.test.ts
+++ b/test/unit/hydration/vite-plugin.test.ts
@@ -130,6 +130,25 @@ describe('InjectHydrationPlugin', () => {
       ))
       expect(result.code).not.toContain(`import { defineNuxtComponent as _defineNuxtComponent } from '#app'`)
     })
+
+    it('should find defineComponent when split across multiple import declarations', async () => {
+      const code = `import { ref } from 'vue'\nimport { defineComponent } from 'vue'\n${exportDefineComponent}`
+      const result = await modifyImportPluginTransform(code, 'test.ts')
+      expect(result.code).toContain(importDefineComponent.trim())
+      expect(result.code).not.toContain(`import { defineComponent } from 'vue'`)
+      expect(result.code).toContain(`import { ref } from 'vue'`)
+    })
+
+    it('should find aliased defineComponent when split across multiple import declarations', async () => {
+      const code = `import { ref } from 'vue'\nimport { defineComponent as _defineComponent } from 'vue'\nexport default _defineComponent({})`
+      const result = await modifyImportPluginTransform(code, 'test.ts')
+      expect(result.code).toContain(genImport(
+        '@nuxt/hints/runtime/hydration/component',
+        [{ name: 'defineComponent', as: '_defineComponent' }],
+      ))
+      expect(result.code).not.toContain(`import { defineComponent as _defineComponent } from 'vue'`)
+      expect(result.code).toContain(`import { ref } from 'vue'`)
+    })
   })
 
   describe('inject-hydration-composable', () => {


### PR DESCRIPTION
 

### 🔗 Linked issue

fix #162 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR makes `findImportSpecifier` look over all importDecl instead of looking for the first import. We can have code like 

```ts
import { ref } from 'vue'
import { defineComponent } from 'vue'
```

that get `defineComponenyt` import from `@nuxt/hints` injected but not having the import from `vue` removed because the first line get matched.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
