### PR TITLE
feat(client): set fold level to 2 when hydration diff > 20 lines

### DIFF
--- a/client/app/components/HydrationIssue.vue
+++ b/client/app/components/HydrationIssue.vue
@@ -32,7 +32,9 @@ async function render(pre: string, post: string) {
   const diff = diffLines(pre, post, { stripTrailingCr: true, ignoreNewlineAtEof: true, newlineIsToken: true, ignoreWhitespace: true })
   diffHtml.value = await codeToHtml(generateDiffHtml(diff), {
     theme: 'github-dark', lang: 'html', transformers: [
-      transformerRenderHtmlFold(),
+      transformerRenderHtmlFold({
+        foldLevel: diff.length > 20 ? 2 : 0,
+      }),
       transformerNotationDiff(),
     ],
   })

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^6.0.1",
     "sass-embedded": "^1.93.3",
     "shiki": "^3.13.0",
-    "shiki-transformer-fold": "^0.1.0",
+    "shiki-transformer-fold": "^0.2.0",
     "vitest": "^4.0.0"
   },
   "packageManager": "pnpm@10.26.2+sha512.0e308ff2005fc7410366f154f625f6631ab2b16b1d2e70238444dd6ae9d630a8482d92a451144debc492416896ed16f7b114a86ec68b8404b2443869e68ffda6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^3.13.0
         version: 3.20.0
       shiki-transformer-fold:
-        specifier: ^0.1.0
-        version: 0.1.1
+        specifier: ^0.2.0
+        version: 0.2.0
       vitest:
         specifier: ^4.0.0
         version: 4.0.16(@types/node@24.10.4)(happy-dom@20.0.11)(jiti@2.6.1)(sass-embedded@1.97.1)(sass@1.97.1)(terser@5.44.1)(yaml@2.8.2)
@@ -4686,8 +4686,8 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
-  shiki-transformer-fold@0.1.1:
-    resolution: {integrity: sha512-04gmLMf+ugyLwbR6VV8IRZjqTWGCa5TDfg74ypsXBmUX/WnByRQRMZ2P91JUOWiPGEGdXIzjNwjO/4YAX+8Zrg==}
+  shiki-transformer-fold@0.2.0:
+    resolution: {integrity: sha512-JWccezM0h+HzptrTNiDla+nJ8ri3njktLEiGZpRq88brdhlvA4WdLtLMStoA/RzwcjVEioSFwl0RrG6caK8NPw==}
 
   shiki@3.20.0:
     resolution: {integrity: sha512-kgCOlsnyWb+p0WU+01RjkCH+eBVsjL1jOwUYWv0YDWkM2/A46+LDKVs5yZCUXjJG6bj4ndFoAg5iLIIue6dulg==}
@@ -5779,7 +5779,7 @@ snapshots:
   '@dxup/nuxt@0.2.2(magicast@0.5.1)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.2.1(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.1)
       chokidar: 4.0.3
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -10662,7 +10662,7 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
-  shiki-transformer-fold@0.1.1: {}
+  shiki-transformer-fold@0.2.0: {}
 
   shiki@3.20.0:
     dependencies:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


Fold the hydration diff when the diff line is above 20. It voids having a big diff being opened by default

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
