### PR TITLE
fix: don't run hydration check if page is not server rendered

### DIFF
--- a/src/runtime/hydration/composables.ts
+++ b/src/runtime/hydration/composables.ts
@@ -10,7 +10,7 @@ export function useHydrationCheck() {
   if (import.meta.server) return
   const nuxtApp = useNuxtApp()
 
-  if (!nuxtApp.isHydrating) {
+  if (!nuxtApp.isHydrating || !nuxtApp.payload.serverRendered) {
     return
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/hints/issues/197
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pR prevent the composable for hydration check from running when page is not server rendererd

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
