### PR TITLE
fix(lazy-load): avoid wrapping glob imports

### DIFF
--- a/src/plugins/lazy-load.ts
+++ b/src/plugins/lazy-load.ts
@@ -11,6 +11,8 @@ import type { Component } from '@nuxt/schema'
 const INCLUDE_FILES = /\.(vue|tsx?|jsx?)$/
 // Exclude node_moduels as users can have control over it
 const EXCLUDE_NODE_MODULES = /node_modules/
+
+const VITE_GLOB_RE = /^__glob_\d+_\d+$/
 const skipPath = normalizePath(resolve(distDir, 'runtime/lazy-load'))
 
 export const LazyLoadHintPlugin = createUnplugin(() => {
@@ -56,6 +58,10 @@ export const LazyLoadHintPlugin = createUnplugin(() => {
           for (const specifier of importDecl.specifiers ?? []) {
             if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportSpecifier') {
               const localName = specifier.local.name
+
+              // skip vite glob-generated imports
+              // https://github.com/nuxt/hints/issues/262
+              if (VITE_GLOB_RE.test(localName)) continue
 
               directComponentImports.push({
                 name: localName,

--- a/test/unit/hydration/lazy-hydration-plugin.test.ts
+++ b/test/unit/hydration/lazy-hydration-plugin.test.ts
@@ -99,6 +99,30 @@ describe('LazyLoadHintPlugin', () => {
       const result = await transform(code, '/src/Parent.vue')
       expect(result).toBeUndefined()
     })
+
+    // https://github.com/nuxt/hints/issues/262
+    it('should not transform Vite glob-generated imports (__glob_N_N pattern)', async () => {
+      const code = [
+        `import { default as __glob_0_0 } from './components/A.vue'`,
+        `import { default as __glob_0_1 } from './components/B.vue'`,
+        `const modules = { './components/A.vue': __glob_0_0, './components/B.vue': __glob_0_1 }`,
+        `export default {}`,
+      ].join('\n')
+      const result = await transform(code, '/src/composables/useComponent.ts')
+      expect(result).toBeUndefined()
+    })
+
+    it('should only wrap non-glob imports when mixed with glob-generated imports', async () => {
+      const code = [
+        `import { default as __glob_0_0 } from './components/A.vue'`,
+        `import MyComp from './MyComp.vue'`,
+        `export default { components: { MyComp } }`,
+      ].join('\n')
+      const result = await transform(code, '/src/Parent.vue')
+      expect(result.code).toContain(`import { default as __glob_0_0 } from './components/A.vue'`)
+      expect(result.code).toContain('import __original_MyComp from \'./MyComp.vue\'')
+      expect(result.code).toContain(`__wrapImportedComponent(__original_MyComp, 'MyComp'`)
+    })
   })
 
   describe('nuxt auto-imported components (__nuxt prefix)', () => {


### PR DESCRIPTION
### 🔗 Linked issue

fix #262 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Ignore imports using import.meta.glob for lazy-laod feature

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
