### PR TITLE
fix(web-vitals): correct next-gen image format detection logic

### DIFF
--- a/src/runtime/web-vitals/plugin.client.ts
+++ b/src/runtime/web-vitals/plugin.client.ts
@@ -81,7 +81,7 @@ export default defineNuxtPlugin({
           if (hasImageFormat(performanceEntry.element.src)) {
             if (
               !performanceEntry.element.src.includes('webp')
-              || !performanceEntry.element.src.includes('avif')
+              && !performanceEntry.element.src.includes('avif')
             ) {
               logger.warn(
                 '[performance] LCP Element can be served in a next gen format like `webp` or `avif` \n\n Learn more: https://web.dev/choose-the-right-image-format/ \n\n Use: https://image.nuxt.com/usage/nuxt-img#format',


### PR DESCRIPTION
The LCP image format check warns users to serve images in next-gen formats (webp/avif), but the condition `!src.includes('webp') || !src.includes('avif')` is always true because no URL contains both format strings simultaneously. By De Morgan's law, `!A || !B` = `!(A && B)`, so even a `.webp` image triggers the warning.

Changing to `&&` makes the check work as intended: only warn when the image is neither webp nor avif.