### PR TITLE
fix: prevent circular reference stack overflow in payload.__hints

### DIFF
--- a/src/runtime/hydration/composables.ts
+++ b/src/runtime/hydration/composables.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, inject, onMounted } from 'vue'
+import { getCurrentInstance, inject, markRaw, onMounted } from 'vue'
 import { useNuxtApp } from '#imports'
 import { HYDRATION_ROUTE, formatHTML, logger } from './utils'
 import type { HydrationMismatchPayload } from './types'
@@ -46,8 +46,8 @@ export function useHydrationCheck() {
         }).then((payload) => {
           nuxtApp.payload.__hints.hydration.push({
             ...payload,
-            instance,
-            vnode: vnodePrehydration,
+            instance: markRaw(instance),
+            vnode: markRaw(vnodePrehydration),
           })
         })
       }

--- a/src/runtime/third-party-scripts/plugin.client.ts
+++ b/src/runtime/third-party-scripts/plugin.client.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, ref, useNuxtApp } from '#imports'
+import { defineNuxtPlugin, shallowRef, useNuxtApp } from '#imports'
 import { defu } from 'defu'
 import { logger } from './utils'
 import { getFeatureOptions } from '../core/features'
@@ -59,7 +59,7 @@ export default defineNuxtPlugin({
     }
 
     nuxtApp.payload.__hints = defu(nuxtApp.payload.__hints, {
-      thirdPartyScripts: ref<{ element: HTMLScriptElement, loaded: boolean }[]>([]),
+      thirdPartyScripts: shallowRef<{ element: HTMLScriptElement, loaded: boolean }[]>([]),
     })
     const scripts = nuxtApp.payload.__hints.thirdPartyScripts
 

--- a/src/runtime/web-vitals/plugin.client.ts
+++ b/src/runtime/web-vitals/plugin.client.ts
@@ -1,7 +1,7 @@
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { onINP, onLCP, onCLS } from 'web-vitals/attribution'
 import { defu } from 'defu'
-import { ref } from 'vue'
+import { shallowRef } from 'vue'
 import { logger } from './utils'
 import { getFeatureOptions } from '../core/features'
 
@@ -46,9 +46,9 @@ export default defineNuxtPlugin({
 
     nuxtApp.payload.__hints = defu(nuxtApp.payload.__hints, {
       webvitals: {
-        lcp: ref([]),
-        inp: ref([]),
-        cls: ref([]),
+        lcp: shallowRef([]),
+        inp: shallowRef([]),
+        cls: shallowRef([]),
       },
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #284 caused by #240

### 📚 Description

#### Problem

PR #240 moved hints data from `nuxtApp.__hints` to `nuxtApp.payload.__hints`. 

Since `payload` is reactive, Vue's `traverse()` recurses infinitely on circular references (component instances, vnodes, DOM elements), causing `RangeError: Maximum call stack size exceeded`.

This only happens when the application has for example hydration error's and the hints module is displaying them.

#### Fix
With this fix all deep-traverses should be fixed. The plain [] inside the reactive payload and the ref() to shallowRef()

- **hydration/composables.ts**: Wrap `instance` and `vnode` with `markRaw()` before storing in payload
- **web-vitals/plugin.client.ts**: Use `shallowRef()` instead of `ref()` (metrics contain DOM element references)
- **third-party-scripts/plugin.client.ts**: Use `shallowRef()` instead of `ref()` (stores `HTMLScriptElement` references)

