### PR TITLE
fix(third-paty): wrap hookable callHook with promise.resolve

### DIFF
--- a/src/runtime/third-party-scripts/plugin.client.ts
+++ b/src/runtime/third-party-scripts/plugin.client.ts
@@ -115,7 +115,7 @@ export default defineNuxtPlugin({
       if (!script.crossOrigin) {
         logger.warn(`Third-party script "${script.src}" is missing crossorigin attribute. Consider adding crossorigin="anonymous" for better security and error reporting.`)
       }
-      nuxtApp.callHook('hints:scripts:added', script)
+      Promise.resolve(nuxtApp.callHook('hints:scripts:added', script))
         .then(() => {
           if (!script.loaded) {
             script.addEventListener('load', () => {


### PR DESCRIPTION
### 🔗 Linked issue

fix #302

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Wrap callHook with `promise.resolve` to avoid calling `.then` on a possible non promise

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
