### PR TITLE
fix: correct router registration

### DIFF
--- a/src/devtools-handlers.ts
+++ b/src/devtools-handlers.ts
@@ -33,7 +33,7 @@ export {
 
 function createHintsRouter() {
   const router = createRouter({
-    preemptive: true
+    preemptive: true,
   })
 
   router.get('/hydration', hydrationGet)

--- a/src/devtools-handlers.ts
+++ b/src/devtools-handlers.ts
@@ -20,6 +20,7 @@ import {
   postHandler as htmlValidatePost,
   deleteHandler as htmlValidateDelete,
 } from './runtime/html-validate/api-handlers'
+import { addDevServerHandler } from '@nuxt/kit'
 
 export {
   getHydrationMismatches,
@@ -30,8 +31,10 @@ export {
   clearHtmlValidateReport,
 }
 
-export function createHintsRouter() {
-  const router = createRouter()
+function createHintsRouter() {
+  const router = createRouter({
+    preemptive: true
+  })
 
   router.get('/hydration', hydrationGet)
   router.post('/hydration', hydrationPost)
@@ -46,4 +49,13 @@ export function createHintsRouter() {
   router.delete('/html-validate/:id', htmlValidateDelete)
 
   return router
+}
+
+export function registerDevServerHandlers() {
+  const router = createHintsRouter()
+
+  addDevServerHandler({
+    route: '/__nuxt_hints',
+    handler: router.handler,
+  })
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -7,7 +7,7 @@ import { joinURL } from 'ufo'
 import type { HintsClientFunctions, HintsServerFunctions } from './runtime/core/rpc-types'
 import { RPC_NAMESPACE } from './runtime/core/rpc-types'
 import {
-   getHydrationMismatches,
+  getHydrationMismatches,
   clearHydrationMismatches,
   getLazyLoadHints,
   clearLazyLoadHint,

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -7,13 +7,13 @@ import { joinURL } from 'ufo'
 import type { HintsClientFunctions, HintsServerFunctions } from './runtime/core/rpc-types'
 import { RPC_NAMESPACE } from './runtime/core/rpc-types'
 import {
-  createHintsRouter,
-  getHydrationMismatches,
+   getHydrationMismatches,
   clearHydrationMismatches,
   getLazyLoadHints,
   clearLazyLoadHint,
   getHtmlValidateReports,
   clearHtmlValidateReport,
+  registerDevServerHandlers,
 } from './devtools-handlers'
 
 const DEVTOOLS_UI_ROUTE = '/__nuxt-hints'
@@ -54,10 +54,7 @@ export function setupDevToolsUI(nuxt: Nuxt, resolver: Resolver) {
     },
   }, nuxt)
 
-  addDevServerHandler({
-    route: '/__nuxt_hints',
-    handler: createHintsRouter().handler,
-  })
+  registerDevServerHandlers()
 
   onDevToolsInitialized(() => {
     const rpc = extendServerRpc<HintsClientFunctions, HintsServerFunctions>(RPC_NAMESPACE, {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Fix the nuxt hints sub-router not being registered resulting in 404 for hints requests

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
