### PR TITLE
fix: ignore style serialization-only hydration diffs

### DIFF
--- a/src/runtime/hydration/composables.ts
+++ b/src/runtime/hydration/composables.ts
@@ -1,6 +1,6 @@
 import { getCurrentInstance, inject, markRaw, onMounted } from 'vue'
 import { useNuxtApp } from '#imports'
-import { HYDRATION_ROUTE, formatHTML, logger } from './utils'
+import { HYDRATION_ROUTE, formatHTML, logger, normalizeHTMLForComparison } from './utils'
 import type { HydrationMismatchPayload } from './types'
 import { clientOnlySymbol } from '#app/components/client-only'
 import { isFeatureDevtoolsEnabled } from '../core/features'
@@ -30,7 +30,7 @@ export function useHydrationCheck() {
 
   onMounted(() => {
     const htmlPostHydration = formatHTML(instance.vnode.el?.outerHTML)
-    if (htmlPreHydration !== htmlPostHydration) {
+    if (normalizeHTMLForComparison(htmlPreHydration) !== normalizeHTMLForComparison(htmlPostHydration)) {
       const componentName = instance.type.name ?? instance.type.displayName ?? instance.type.__name
       const fileLocation = instance.type.__file ?? 'unknown'
       const body = {

--- a/src/runtime/hydration/utils.ts
+++ b/src/runtime/hydration/utils.ts
@@ -34,3 +34,53 @@ export function formatHTML(html: string | undefined): string {
 
   return formatted.trim()
 }
+
+export function normalizeHTMLForComparison(html: string): string {
+  return html.replace(/\sstyle=(["'])(.*?)\1/gs, (_, quote: string, style: string) => {
+    return ` style=${quote}${normalizeStyleAttribute(style)}${quote}`
+  })
+}
+
+function normalizeStyleAttribute(style: string): string {
+  return style
+    .split(';')
+    .map(declaration => declaration.trim())
+    .filter(Boolean)
+    .map((declaration) => {
+      const separatorIndex = declaration.indexOf(':')
+      if (separatorIndex === -1) {
+        return declaration
+      }
+
+      const property = declaration.slice(0, separatorIndex).trim()
+      const value = normalizeStyleValue(declaration.slice(separatorIndex + 1).trim())
+      return `${property}:${value}`
+    })
+    .join(';')
+}
+
+function normalizeStyleValue(value: string): string {
+  let normalized = ''
+  let quote: string | undefined
+
+  for (let index = 0; index < value.length; index++) {
+    const char = value[index]
+    const previous = value[index - 1]
+
+    if ((char === '"' || char === '\'') && previous !== '\\') {
+      quote = quote === char ? undefined : quote ?? char
+    }
+
+    if (!quote && char === ',') {
+      normalized += char
+      while (/\s/.test(value[index + 1] ?? '')) {
+        index++
+      }
+      continue
+    }
+
+    normalized += char
+  }
+
+  return normalized
+}

--- a/test/unit/hydration/utils.test.ts
+++ b/test/unit/hydration/utils.test.ts
@@ -15,6 +15,27 @@ describe('normalizeHTMLForComparison', () => {
     expect(normalizeHTMLForComparison(pre)).toBe(normalizeHTMLForComparison(post))
   })
 
+  it('ignores trailing style semicolons', async () => {
+    const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
+    const pre = '<div style="color:red;">'
+    const post = '<div style="color:red">'
+
+    expect(normalizeHTMLForComparison(pre)).toBe(normalizeHTMLForComparison(post))
+  })
+
+  it('keeps html without style attributes unchanged', async () => {
+    const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
+    const html = '<div class="example">content</div>'
+
+    expect(normalizeHTMLForComparison(html)).toBe(html)
+  })
+
+  it('handles empty style attributes', async () => {
+    const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
+
+    expect(normalizeHTMLForComparison('<div style="">')).toBe('<div style="">')
+  })
+
   it('keeps real style value differences visible', async () => {
     const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
     const pre = '<div style="--demo-gap:0px;">'

--- a/test/unit/hydration/utils.test.ts
+++ b/test/unit/hydration/utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('#shared/hints-config', () => ({
+  features: {
+    hydration: true,
+  },
+}))
+
+describe('normalizeHTMLForComparison', () => {
+  it('ignores style serialization whitespace differences', async () => {
+    const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
+    const pre = '<div style="--demo-size:var(--demo-source);--demo-color:rgb(0, 0, 0);--demo-gap:0px;">'
+    const post = '<div style="--demo-size:var(--demo-source);--demo-color:rgb(0,0,0);--demo-gap:0px;">'
+
+    expect(normalizeHTMLForComparison(pre)).toBe(normalizeHTMLForComparison(post))
+  })
+
+  it('keeps real style value differences visible', async () => {
+    const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
+    const pre = '<div style="--demo-gap:0px;">'
+    const post = '<div style="--demo-gap:1px;">'
+
+    expect(normalizeHTMLForComparison(pre)).not.toBe(normalizeHTMLForComparison(post))
+  })
+
+  it('keeps quoted comma whitespace differences visible', async () => {
+    const { normalizeHTMLForComparison } = await import('../../../src/runtime/hydration/utils')
+    const pre = '<div style="content:\'a, b\';">'
+    const post = '<div style="content:\'a,b\';">'
+
+    expect(normalizeHTMLForComparison(pre)).not.toBe(normalizeHTMLForComparison(post))
+  })
+})


### PR DESCRIPTION

### 🔗 Linked issue

Resolves #351

### 📚 Description

This PR fixes a false positive in the hydration checker when the only difference between pre-hydration and post-hydration HTML is equivalent inline `style` serialization.

The issue shows up when the browser/client serializes CSS values slightly differently than the server-rendered HTML. For example:

```diff
- style="--demo-size:var(--demo-source);--demo-color:rgb(0, 0, 0);--demo-gap:0px;"
+ style="--demo-size:var(--demo-source);--demo-color:rgb(0,0,0);--demo-gap:0px;"
```

Those declarations are semantically the same, but the current checker compares formatted `outerHTML` strings directly, so it reports a hydration mismatch even though there is no meaningful DOM/CSS mismatch.

The change keeps the fix narrow:

- normalize inline `style` attributes before comparing pre/post hydration HTML
- keep the original pre/post HTML in the mismatch payload when a real mismatch is found
- preserve real style value differences as mismatches
- avoid normalizing comma whitespace inside quoted CSS strings

I added unit tests for the style serialization case and for the guard cases where differences should still be reported.

Verification run locally:

```sh
pnpm exec eslint src/runtime/hydration/composables.ts src/runtime/hydration/utils.ts test/unit/hydration/utils.test.ts
pnpm vitest run test/unit/hydration/utils.test.ts
pnpm vitest run --project unit
pnpm pack --pack-destination /tmp
```

I also verified the packed module against the reproduction from #351. After installing the local tarball into the repro, opening the page in a browser, and querying the hydration endpoint, it returned:

