### PR TITLE
fix: respect app.baseURL for dev endpoints and the devtools client

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -56,7 +56,7 @@ export function setupDevToolsUI(nuxt: Nuxt, resolver: Resolver) {
         // SPA document/navigation → serve the entry HTML with the base
         // rewritten. (sirv on its own would serve the unrewritten `index.html`
         // for the mount root, which is the bug this avoids.)
-        const path = (req.url || '/').split('?')[0]
+        const path = (req.url || '/').split('?')[0] || '/'
         const isAsset = path !== '/' && /\.[a-z0-9]+$/i.test(path)
         if (isAsset) {
           return serveAssets(req, res, next)

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,5 +1,7 @@
 import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
 import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import type { Nuxt } from '@nuxt/schema'
 import { addDevServerHandler, type Resolver } from '@nuxt/kit'
 import { proxyRequest, eventHandler } from 'h3'
@@ -17,26 +19,67 @@ import {
 } from './devtools-handlers'
 
 const DEVTOOLS_UI_ROUTE = '/__nuxt-hints'
+const HINTS_API_ROUTE = '/__nuxt_hints'
 const DEVTOOLS_UI_LOCAL_PORT = 3300
 
 export function setupDevToolsUI(nuxt: Nuxt, resolver: Resolver) {
   const clientPath = resolver.resolve('./client')
   const isProductionBuild = existsSync(clientPath)
 
+  // Every dev endpoint must live under the host app's baseURL. The client
+  // plugins reach the API with `$fetch` (which prepends `app.baseURL`) and the
+  // devtools iframe loads the UI from the base-prefixed `src` below, so the bare
+  // routes are never the ones the browser actually requests. Registering them
+  // bare makes the requests miss and fall through to the host SSR renderer
+  // (producing `[Vue Router warn]: No match found …`). `joinURL` is a no-op when
+  // `baseURL` is "/", so the default setup is unaffected.
+  const base = nuxt.options.app?.baseURL || '/'
+  const devtoolsUiRoute = joinURL(base, DEVTOOLS_UI_ROUTE)
+  const hintsApiRoute = joinURL(base, HINTS_API_ROUTE)
+
   // Serve production-built client (used when package is published)
   if (isProductionBuild) {
     nuxt.hook('vite:serverCreated', async (server) => {
       const sirv = await import('sirv').then(r => r.default || r)
-      server.middlewares.use(
-        DEVTOOLS_UI_ROUTE,
-        sirv(clientPath, { dev: true, single: true }),
-      )
+      const serveAssets = sirv(clientPath, { dev: true })
+      server.middlewares.use(devtoolsUiRoute, async (req, res, next) => {
+        // The client is a prebuilt `ssr: false` Nuxt app with
+        // `app.baseURL: '/__nuxt-hints'` compiled into its HTML (the inline
+        // `__NUXT__` config + asset URLs). When the host app uses a non-root
+        // baseURL we mount it at `devtoolsUiRoute`, so its baked references have
+        // to be rewritten to match — otherwise the SPA's router and asset URLs
+        // point at the bare path and the panel 404s. When `base` is "/",
+        // `devtoolsUiRoute === DEVTOOLS_UI_ROUTE` and the rewrite is a no-op.
+        //
+        // Asset requests (anything with a file extension, e.g. `/_nuxt/*.js`)
+        // are real files → hand them to sirv untouched. Everything else is an
+        // SPA document/navigation → serve the entry HTML with the base
+        // rewritten. (sirv on its own would serve the unrewritten `index.html`
+        // for the mount root, which is the bug this avoids.)
+        const path = (req.url || '/').split('?')[0]
+        const isAsset = path !== '/' && /\.[a-z0-9]+$/i.test(path)
+        if (isAsset) {
+          return serveAssets(req, res, next)
+        }
+        try {
+          const html = await readFile(join(clientPath, 'index.html'), 'utf8')
+          res.setHeader('content-type', 'text/html;charset=utf-8')
+          res.end(
+            devtoolsUiRoute === DEVTOOLS_UI_ROUTE
+              ? html
+              : html.replaceAll(DEVTOOLS_UI_ROUTE, devtoolsUiRoute),
+          )
+        }
+        catch {
+          next()
+        }
+      })
     })
   }
   // In local development, start a separate Nuxt Server and proxy to serve the client
   else {
     addDevServerHandler({
-      route: DEVTOOLS_UI_ROUTE,
+      route: devtoolsUiRoute,
       handler: eventHandler((e) => {
         return proxyRequest(e, 'http://localhost:' + DEVTOOLS_UI_LOCAL_PORT + DEVTOOLS_UI_ROUTE + e.path)
       }),
@@ -50,12 +93,12 @@ export function setupDevToolsUI(nuxt: Nuxt, resolver: Resolver) {
     category: 'analyze',
     view: {
       type: 'iframe',
-      src: joinURL(nuxt.options.app?.baseURL || '/', DEVTOOLS_UI_ROUTE),
+      src: devtoolsUiRoute,
     },
   }, nuxt)
 
   addDevServerHandler({
-    route: '/__nuxt_hints',
+    route: hintsApiRoute,
     handler: createHintsRouter().handler,
   })
 

--- a/src/runtime/html-validate/api-handlers.ts
+++ b/src/runtime/html-validate/api-handlers.ts
@@ -36,6 +36,9 @@ export const postHandler = defineEventHandler(async (event) => {
   }
   storeHtmlValidateReport(body)
   setResponseStatus(event, 201)
+  // Return a value so h3 terminates instead of passing the request through to
+  // the host SSR renderer (which would log a Vue Router "No match" warning).
+  return null
 })
 
 export const deleteHandler = defineEventHandler(async (event) => {
@@ -45,4 +48,6 @@ export const deleteHandler = defineEventHandler(async (event) => {
   }
   clearHtmlValidateReport(id)
   setResponseStatus(event, 204)
+  // See postHandler: return a value so h3 does not pass the request through.
+  return null
 })

--- a/src/runtime/hydration/handlers.ts
+++ b/src/runtime/hydration/handlers.ts
@@ -49,6 +49,9 @@ export const deleteHandler = defineEventHandler(async (event) => {
   }
   clearHydrationMismatches(body.id)
   setResponseStatus(event, 204)
+  // Return a value so h3 terminates instead of passing the request through to
+  // the host SSR renderer (which would log a Vue Router "No match" warning).
+  return null
 })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/runtime/lazy-load/handlers.ts
+++ b/src/runtime/lazy-load/handlers.ts
@@ -38,6 +38,11 @@ export const postHandler = defineEventHandler(async (event) => {
     getRPC()?.onLazyLoadReport(parsed)
   }
   setResponseStatus(event, 201)
+  // Return a body so h3 terminates the request here. A bare `setResponseStatus`
+  // with no return value leaves the handler returning `undefined`, which h3
+  // treats as pass-through middleware — the request then continues to the host
+  // SSR renderer and triggers a `[Vue Router warn]: No match found` warning.
+  return null
 })
 
 export const deleteHandler = defineEventHandler(async (event) => {
@@ -54,4 +59,6 @@ export const deleteHandler = defineEventHandler(async (event) => {
   lazyLoadData.push(...next)
   getRPC()?.onLazyLoadCleared(id)
   setResponseStatus(event, 204)
+  // See postHandler: return a value so h3 does not pass the request through.
+  return null
 })


### PR DESCRIPTION
Fixes #361.

## Problem

`@nuxt/hints` assumes `app.baseURL === "/"`. Under a non-root base, its dev
endpoints and devtools UI are registered/served at **bare** paths while the
browser requests them **base-prefixed**, so the requests miss and fall through to
the host app's SSR renderer — logging `[Vue Router warn]: No match found …` and
leaving the Hints panel rendering its own 404.

PR #322 (issue #321) base-prefixed the devtools iframe `src` but not the
middleware that serves it, and didn't touch the telemetry endpoint — so the
module is still broken under a non-root base in 1.1.3. Full analysis in #361.

## Changes

- **`devtools.ts`** — register the telemetry router and the devtools-UI route
  under `app.baseURL`, matching the iframe `src` that #322 already prefixed.
  `joinURL` is a no-op when `baseURL` is `/`, so the default setup is unchanged.
- **`devtools.ts`** — the prebuilt `ssr: false` client bakes
  `app.baseURL = '/__nuxt-hints'` into its served HTML (the inline `__NUXT__`
  config + asset URLs). Serve static assets via `sirv` and serve the entry HTML
  with that base rewritten to where the client is actually mounted, so the panel
  routes and loads its assets under a non-root base instead of 404ing. This is
  the half #322 left unfinished.
- **handlers** (`lazy-load` / `hydration` / `html-validate`) — the POST/DELETE
  handlers called `setResponseStatus(...)` and then returned `undefined`, which
  h3 treats as pass-through middleware; the request then continued to the host
  SSR renderer. They now `return null` so the response terminates.

## Testing

Verified end-to-end against a minimal **vanilla Nuxt 4.4.8** reproduction, with
this fix pinned via a vendored build:

- Repro: https://github.com/OliverRC/nuxt-hints-base-url-repro
- Branch pinning this fix: https://github.com/OliverRC/nuxt-hints-base-url-repro/tree/test/with-baseurl-fix

| | base `/repro/` | base `/` (regression) |
| --- | --- | --- |
| `GET …/__nuxt_hints/hydration` | 200 | 200 |
| `POST …/__nuxt_hints/lazy-load` | 201 | 201 |
| `GET …/__nuxt-hints` (panel) | 200 | 200 |
| panel HTML base | rewritten → `/repro/__nuxt-hints` | stays `/__nuxt-hints` |
| Vue Router "No match" warnings | **0** | **0** |

`pnpm lint` and `tsc --noEmit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
