### PR TITLE
feat: make devtools header sticky

### DIFF
--- a/client/app/components/Header.vue
+++ b/client/app/components/Header.vue
@@ -8,15 +8,20 @@ const pageTitle = computed(() => {
 
 <template>
   <header
+    sticky
+    top-0
+    z-10
     flex
     px-4
     border="b base"
+    w-full
     h-49px
     items-center
     font-semibold
     text-neutral-800
     dark:text-white
     gap-1
+    n-bg-base
     n-border-base
   >
     <NuxtLink


### PR DESCRIPTION
### 📚 Description

Small PR that makes the devtools header sticky so you don't need to scroll back to top before being able to go to the index page.

In my case I had a lot of reports about `transform` being added to my elements and it was a chore to scroll down and then back up again every time I wanted to go to a different hints page.

- `w-full` necessary fix for webkit to make sure the header fills its container (might have been an issue before since I was seeing it centered with instrinsic width)
- `n-bg-base` gives the header the same background classes we get from the devtools kit to ensure consistency with everything else