### PR TITLE
fix(html-validate): wrap validation in a try/catch

### DIFF
--- a/src/runtime/html-validate/nitro.plugin.ts
+++ b/src/runtime/html-validate/nitro.plugin.ts
@@ -31,7 +31,7 @@ const DEFAULT_RULES: RuleConfig = {
   'no-inline-style': 'off',
 }
 
-export default <NitroAppPlugin>function (nitro) {
+export default <NitroAppPlugin> function (nitro) {
   const opts: ConfigData = defu({
     extends: DEFAULT_EXTENDS,
     rules: DEFAULT_RULES,
@@ -63,7 +63,8 @@ export default <NitroAppPlugin>function (nitro) {
             nitro.captureError(error instanceof Error ? error : new Error(String(error)), { event })
           })
         }
-      } catch (error) {
+      }
+      catch (error) {
         // https://github.com/nuxt/hints/issues/360
         // html validate can throw errors for some html
         console.warn('HTML Validate error:', error instanceof Error ? error.message : String(error))

--- a/src/runtime/html-validate/nitro.plugin.ts
+++ b/src/runtime/html-validate/nitro.plugin.ts
@@ -31,7 +31,7 @@ const DEFAULT_RULES: RuleConfig = {
   'no-inline-style': 'off',
 }
 
-export default <NitroAppPlugin> function (nitro) {
+export default <NitroAppPlugin>function (nitro) {
   const opts: ConfigData = defu({
     extends: DEFAULT_EXTENDS,
     rules: DEFAULT_RULES,
@@ -43,24 +43,30 @@ export default <NitroAppPlugin> function (nitro) {
 
   nitro.hooks.hook('render:response', async (response, { event }) => {
     if (typeof response.body === 'string' && (response.headers?.['Content-Type'] || response.headers?.['content-type'])?.includes('html')) {
-      const formattedBody = await format(response.body, { plugins: [html], parser: 'html' })
-      const results = await validator.validateString(formattedBody)
+      try {
+        const formattedBody = await format(response.body, { plugins: [html], parser: 'html' })
+        const results = await validator.validateString(formattedBody)
 
-      if (response.body && results.errorCount > 0) {
-        const id = randomUUID()
-        const data: HtmlValidateReport = {
-          id,
-          path: event.path,
-          html: formattedBody,
-          results: results.results,
+        if (response.body && results.errorCount > 0) {
+          const id = randomUUID()
+          const data: HtmlValidateReport = {
+            id,
+            path: event.path,
+            html: formattedBody,
+            results: results.results,
+          }
+          response.body = addBeforeBodyEndTag(
+            response.body,
+            `<script id="hints-html-validate" type="application/json">${stringify(data)}</script>`,
+          )
+          nitro.hooks.callHook(HTML_VALIDATE_REPORT_HOOK, data).catch((error) => {
+            nitro.captureError(error instanceof Error ? error : new Error(String(error)), { event })
+          })
         }
-        response.body = addBeforeBodyEndTag(
-          response.body,
-          `<script id="hints-html-validate" type="application/json">${stringify(data)}</script>`,
-        )
-        nitro.hooks.callHook(HTML_VALIDATE_REPORT_HOOK, data).catch((error) => {
-          nitro.captureError(error instanceof Error ? error : new Error(String(error)), { event })
-        })
+      } catch (error) {
+        // https://github.com/nuxt/hints/issues/360
+        // html validate can throw errors for some html
+        console.warn('HTML Validate error:', error instanceof Error ? error.message : String(error))
       }
     }
   })


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/hints/issues/360
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

wraps the validation in a try/catch statement. html-validate can throw with unexpected tags

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
